### PR TITLE
Fix README

### DIFF
--- a/stable/logdna-agent/README.md
+++ b/stable/logdna-agent/README.md
@@ -76,18 +76,15 @@ Save the following defintion into a file (e.g. clusterrole.yaml)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-name: logdna-clusterrole
+  name: logdna-clusterrole
 rules:
-- apiGroups:
-    - ''
-    resources:
-    - pods
-    - secrets
-    - jobs
-    verbs:
-    - get
-    - create
-    - delete
+- apiGroups: ["extensions"]
+  resourceNames: ["ibm-anyuid-hostpath-psp"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "delete", "patch"]
 ```
 
 Run:
@@ -95,27 +92,27 @@ Run:
 kubectl create -f clusterrole.yaml
 ```
 
-- Create ClusterRoleBinding.
+- Create RoleBinding.
 
-Create a ClusterRoleBinding which binds ClusterRole created in previous step to default service account of the namespace.
+Create a RoleBinding which binds ClusterRole created in previous step to default service account of the namespace.
 
 Run:
 
 _(NOTE: replace `<namespace>` with your namespace )_
 
 ```
-kubectl create rolebinding logdna-clusterrolebinding --clusterrole=logdna-clusterrole --serviceaccount=<namespace>:default --namespace=<namespace>
+kubectl create rolebinding logdna-rolebinding --clusterrole=logdna-clusterrole --serviceaccount=<namespace>:default --namespace=<namespace>
 ```
 
-or using ClusterRoleBinding definition:
+or using RoleBinding definition:
 
-Save the following defintion into a file (e.g. clusterrolebinding.yaml)
+Save the following defintion into a file (e.g. rolebinding.yaml)
 
 ```yaml
 - apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-    name: logdna-clusterrolebinding
+    name: logdna-rolebinding
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION
Fix README.md

- The text was referring to `clusterrolebinding` even though we just creating `rolebinding`, I did that mistake. its fixed now.
- Improved the clusterrole based on readings, see docs/refs section below

clusterrole.yaml
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: logdna-clusterrole
rules:
- apiGroups: ["extensions"]
  resourceNames: ["ibm-anyuid-hostpath-psp"]
  resources: ["podsecuritypolicies"]
  verbs: ["use"]
- apiGroups: [""]
  resources: ["secrets"]
  verbs: ["get", "create", "delete", "patch"]
```

This clusterrole uses the `ibm-anyuid-hostpath-psp` and also allows the job to create secrets in the namespace. Earlier we had permissions to create pods & jobs, which is not needed.

Docs/References:
- [cluster role which uses psp](https://github.com/IBM/cloud-pak/blob/master/spec/security/psp/ibm-anyuid-hostpath-cr.yaml)
- [permissions config in Jenkins](https://github.com/IBM/charts/blob/master/community/jenkins/templates/rbac.yaml#L27)
- [k8s example](https://github.com/kubernetes/examples/tree/master/staging/podsecuritypolicy/rbac#roles-and-bindings)

I have tested this deployment with this updated clusterrole config. pods run successfully.
